### PR TITLE
Change login with facebook HTTP method

### DIFF
--- a/src/main/java/com/azkar/controllers/AuthenticationController.java
+++ b/src/main/java/com/azkar/controllers/AuthenticationController.java
@@ -19,7 +19,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -58,7 +58,7 @@ public class AuthenticationController extends BaseController {
    * authentication is expected to be not set.
    * </p>
    */
-  @PostMapping(value = LOGIN_WITH_FACEBOOK_PATH, consumes = MediaType.APPLICATION_JSON_VALUE)
+  @PutMapping(value = LOGIN_WITH_FACEBOOK_PATH, consumes = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<FacebookAuthenticationResponse> loginWithFacebook(
       @RequestBody FacebookAuthenticationBody requestBody) {
     requestBody.validate();
@@ -113,7 +113,7 @@ public class AuthenticationController extends BaseController {
    * facebook information will override the old one. This request is expected to called by a logged
    * in user so the security context authentication is expected to be set.
    */
-  @PostMapping(value = "/connect/facebook", consumes = MediaType.APPLICATION_JSON_VALUE)
+  @PutMapping(value = "/connect/facebook", consumes = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<FacebookAuthenticationResponse> connectFacebook(
       @RequestBody FacebookAuthenticationBody requestBody) {
     requestBody.validate();


### PR DESCRIPTION
@aabdelzaher , PTAL :)

The rationale behind this:
I was actually a little bit hesitant about which methods to choose for those because they are not directly interacting with resources. It seemed that it [is ok](https://stackoverflow.com/questions/978061/http-get-with-request-body) to include a body with any HTTP method, however, it is not preferred by some people.

TBH, I don't care in this case which method to use. But as it seems that flutter HTTP library developers prefer having [no body](https://github.com/dart-lang/http/blob/master/lib/http.dart#L45) with get method, and I was planning to use this library, then I changed the method to put.