### PR TITLE
Reply with PIN on email registration first step success

### DIFF
--- a/src/main/java/com/azkar/controllers/AuthenticationController.java
+++ b/src/main/java/com/azkar/controllers/AuthenticationController.java
@@ -34,6 +34,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -70,7 +71,7 @@ public class AuthenticationController extends BaseController {
     restTemplate = restTemplateBuilder.build();
   }
 
-  @PutMapping(value = REGISTER_WITH_EMAIL_PATH, consumes = MediaType.APPLICATION_JSON_VALUE)
+  @PostMapping(value = REGISTER_WITH_EMAIL_PATH, consumes = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<EmailRegistrationResponse> registerWithEmail(
       @RequestBody EmailRegistrationRequestBody body) {
     EmailRegistrationResponse response = new EmailRegistrationResponse();
@@ -95,12 +96,15 @@ public class AuthenticationController extends BaseController {
 
     sendVerificationEmail(body.getEmail(), pin);
 
-    registrationPinRepo.save(
+    RegistrationEmailConfirmationState state =
         RegistrationEmailConfirmationState.builder()
             .email(body.getEmail())
             .password(passwordEncoder.encode(body.getPassword()))
             .pin(pin)
-            .name(body.getName()).build());
+            .name(body.getName()).build();
+
+    registrationPinRepo.save(state);
+    response.setData(state);
     return ResponseEntity.ok(response);
   }
 

--- a/src/main/java/com/azkar/entities/RegistrationEmailConfirmationState.java
+++ b/src/main/java/com/azkar/entities/RegistrationEmailConfirmationState.java
@@ -1,8 +1,10 @@
 package com.azkar.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
@@ -13,6 +15,8 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document(collection = "registration_with_email_confirmation_states")
 @Builder
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class RegistrationEmailConfirmationState extends EntityBase {
 
   @Id
@@ -20,6 +24,7 @@ public class RegistrationEmailConfirmationState extends EntityBase {
   @NonNull
   @Indexed(name = "email_index", unique = true)
   private String email;
+  @JsonIgnore
   @NonNull
   private String password;
   private int pin;

--- a/src/main/java/com/azkar/payload/authenticationcontroller/responses/EmailRegistrationResponse.java
+++ b/src/main/java/com/azkar/payload/authenticationcontroller/responses/EmailRegistrationResponse.java
@@ -1,13 +1,13 @@
 package com.azkar.payload.authenticationcontroller.responses;
 
+import com.azkar.entities.RegistrationEmailConfirmationState;
 import com.azkar.payload.ResponseBase;
 
-public class EmailRegistrationResponse extends ResponseBase {
+public class EmailRegistrationResponse extends ResponseBase<RegistrationEmailConfirmationState> {
 
   public static final String USER_ALREADY_REGISTERED_ERROR = "This user is already registered.";
   public static final String USER_ALREADY_REGISTERED_WITH_FACEBOOK =
       "The user is already registered with facebook. Please try logging in using facebook.";
   public static final String PIN_ALREADY_SENT_TO_USER_ERROR =
       "A pin has already been sent to the user";
-
 }

--- a/src/test/java/com/azkar/controllers/groupcontroller/GroupMembershipTest.java
+++ b/src/test/java/com/azkar/controllers/groupcontroller/GroupMembershipTest.java
@@ -25,7 +25,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 
 public class GroupMembershipTest extends TestBase {


### PR DESCRIPTION
This CL does the following:
- Changes /register/email put mapping to post mapping.
- Returns the RegistrationEmailConfirmationState if the email registration first step (sending a PIN to the email to be registered) succeeded.

Returning the PIN to the UI will lead to a better user experience when verifying the PIN. This can happen by sending verification requests to the API only when the user entered the correct PIN. Responding to users entering wrong/correct PINs quickly.