### PR TITLE
Add binary group ID to Friend objects

### DIFF
--- a/src/main/java/com/azkar/controllers/ChallengeController.java
+++ b/src/main/java/com/azkar/controllers/ChallengeController.java
@@ -24,8 +24,6 @@ import com.azkar.repos.ChallengeRepo;
 import com.azkar.repos.GroupRepo;
 import com.azkar.repos.UserRepo;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/azkar/controllers/FriendshipController.java
+++ b/src/main/java/com/azkar/controllers/FriendshipController.java
@@ -133,7 +133,11 @@ public class FriendshipController extends BaseController {
       return ResponseEntity.unprocessableEntity().body(response);
     }
 
+    Group binaryGroup = generateBinaryGroup(currentUser, friend.get());
+    groupRepo.save(binaryGroup);
+
     friend.get().setPending(false);
+    friend.get().setGroupId(binaryGroup.getId());
     Friendship otherUserFriendship = friendshipRepo.findByUserId(otherUserId);
 
     otherUserFriendship.getFriends().add(
@@ -142,13 +146,12 @@ public class FriendshipController extends BaseController {
             .username(currentUser.getUsername())
             .name(currentUser.getName())
             .isPending(false)
+            .groupId(binaryGroup.getId())
             .build()
     );
 
     friendshipRepo.save(currentUserFriendship);
     friendshipRepo.save(otherUserFriendship);
-    Group binaryGroup = generateBinaryGroup(currentUser, friend.get());
-    groupRepo.save(binaryGroup);
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/azkar/entities/Friendship.java
+++ b/src/main/java/com/azkar/entities/Friendship.java
@@ -46,6 +46,7 @@ public class Friendship extends EntityBase {
 
     @NonNull
     private String userId;
+    private String groupId;
     @NonNull
     private String username;
     @NonNull

--- a/src/test/java/com/azkar/controllers/friendshipcontroller/FriendshipTest.java
+++ b/src/test/java/com/azkar/controllers/friendshipcontroller/FriendshipTest.java
@@ -2,6 +2,7 @@ package com.azkar.controllers.friendshipcontroller;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -172,6 +173,8 @@ public class FriendshipTest extends TestBase {
     assertThat(group.getUsersIds().contains(user1.getId()), is(true));
     assertThat(group.getUsersIds().contains(user2.getId()), is(true));
 
+    assertThat(user1Friend.getGroupId(), notNullValue());
+    assertThat(user1Friend.getGroupId(), equalTo(user2Friend.getGroupId()));
   }
 
   @Test


### PR DESCRIPTION
This commit adds the ID of the auto-generated binary group to the Friend
objects of both sides of friendship so as to make it easier to retrieve
that group given a friendship.