### PR TITLE
Using ant patterns to match requests with pre-authenticated allowed endpoints by 

### DIFF
--- a/src/main/java/com/azkar/configs/SecurityConfig.java
+++ b/src/main/java/com/azkar/configs/SecurityConfig.java
@@ -20,7 +20,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
-  public static final String[] PRE_AUTHENTICAITON_ALLOWED_ENDPOINTS = {
+  public static final String[] PRE_AUTHENTICAITON_ALLOWED_ENDPOINT_PATTERNS = {
       AuthenticationController.REGISTER_WITH_EMAIL_PATH,
       AuthenticationController.VERIFY_EMAIL_PATH,
       AuthenticationController.LOGIN_WITH_EMAIL_PATH,
@@ -34,9 +34,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   @Override
   protected void configure(HttpSecurity http) throws Exception {
     http.authorizeRequests()
-        .antMatchers(PRE_AUTHENTICAITON_ALLOWED_ENDPOINTS)
-        .permitAll()
-        .antMatchers()
+        .antMatchers(PRE_AUTHENTICAITON_ALLOWED_ENDPOINT_PATTERNS)
         .permitAll()
         .antMatchers("/**")
         .authenticated()

--- a/src/main/java/com/azkar/configs/authentication/JwtAuthenticationFilter.java
+++ b/src/main/java/com/azkar/configs/authentication/JwtAuthenticationFilter.java
@@ -22,6 +22,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
@@ -40,9 +41,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       FilterChain filterChain)
       throws ServletException, IOException {
     // TODO(issue#111): Find a better way to not run JwtAuthenticationFilter for some URLs.
-    if (Arrays.stream(SecurityConfig.PRE_AUTHENTICAITON_ALLOWED_ENDPOINTS).filter(
-        (preAuthenticationAllowedEndpoint) -> preAuthenticationAllowedEndpoint
-            .equals(httpServletRequest.getRequestURI())).findAny().isPresent()) {
+    if (uriMatchesAnyPattern(httpServletRequest.getRequestURI(),
+        SecurityConfig.PRE_AUTHENTICAITON_ALLOWED_ENDPOINT_PATTERNS)) {
       logger.info("No JWT authentication needed.");
 
       filterChain.doFilter(httpServletRequest, httpServletResponse);
@@ -82,6 +82,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
       setUnAuthenticatedResponse(httpServletResponse);
     }
+  }
+
+  private boolean uriMatchesAnyPattern(String uri, String[] patterns) {
+    AntPathMatcher antPathMatcher = new AntPathMatcher();
+    return Arrays.stream(patterns).anyMatch(
+        (preAuthenticationAllowedEndpoint) -> antPathMatcher
+            .match(preAuthenticationAllowedEndpoint, uri)
+    );
   }
 
   private void setUnAuthenticatedResponse(HttpServletResponse httpServletResponse)


### PR DESCRIPTION
Matching pre-authenticated allowed endpoints by ant patterns instead of string equality