### PR TITLE
Change tomcat version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 
   <properties>
     <java.version>1.8</java.version>
+    <tomcat.version>9.0.30</tomcat.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This change is done because the default tomcat version that is being
used by spring boot had issues with handling large requests (it sometimes truncates the request bodies).
https://medium.com/javarevisited/how-we-found-apache-tomcat-couldnt-handle-large-requests-fd41b8b5f8e7