### PR TITLE
Support users who want to find friends

### DIFF
--- a/src/main/java/com/azkar/entities/PubliclyAvailableFemaleUser.java
+++ b/src/main/java/com/azkar/entities/PubliclyAvailableFemaleUser.java
@@ -1,0 +1,33 @@
+package com.azkar.entities;
+
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/*
+Publicly available females are users who want their names to be publicly available in a list that
+can be used by females to send friend requests to each other.
+ */
+@Document(collection = "publicly_available_female_users")
+@Builder(toBuilder = true)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PubliclyAvailableFemaleUser extends EntityBase {
+
+  @Indexed
+  @Id
+  private String id;
+  @Indexed
+  private String userId;
+  @NotNull
+  private String firstName;
+  @NotNull
+  private String lastName;
+
+}

--- a/src/main/java/com/azkar/entities/PubliclyAvailableMaleUser.java
+++ b/src/main/java/com/azkar/entities/PubliclyAvailableMaleUser.java
@@ -1,0 +1,33 @@
+package com.azkar.entities;
+
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/*
+Publicly available males are users who want their names to be publicly available in a list that
+can be used by males to send friend requests to each other.
+ */
+@Document(collection = "publicly_available_male_users")
+@Builder(toBuilder = true)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PubliclyAvailableMaleUser extends EntityBase {
+
+  @Indexed
+  @Id
+  private String id;
+  @Indexed
+  private String userId;
+  @NotNull
+  private String firstName;
+  @NotNull
+  private String lastName;
+
+}

--- a/src/main/java/com/azkar/payload/ResponseBase.java
+++ b/src/main/java/com/azkar/payload/ResponseBase.java
@@ -72,6 +72,8 @@ public abstract class ResponseBase<T> {
     public static final int TAFSEER_CHALLENGE_INCORRECT_NUMBER_OF_WORDS_ERROR = 52;
     public static final int CANNOT_REMOVE_SABEQ__FROM_FRIENDS_ERROR = 53;
     public static final int STARTING_VERSE_AFTER_ENDING_VERSE_ERROR = 54;
+    public static final int USER_NOT_ADDED_TO_PUBLICLY_AVAILABLE_USERS_ERROR = 55;
+    public static final int USER_ALREADY_IS_PUBLICLY_AVAILABLE_USER_ERROR = 56;
 
     public int code;
 

--- a/src/main/java/com/azkar/payload/usercontroller/responses/AddToPubliclyAvailableUsersResponse.java
+++ b/src/main/java/com/azkar/payload/usercontroller/responses/AddToPubliclyAvailableUsersResponse.java
@@ -1,0 +1,7 @@
+package com.azkar.payload.usercontroller.responses;
+
+import com.azkar.payload.ResponseBase;
+
+public class AddToPubliclyAvailableUsersResponse extends ResponseBase {
+
+}

--- a/src/main/java/com/azkar/payload/usercontroller/responses/DeleteFromPubliclyAvailableUsers.java
+++ b/src/main/java/com/azkar/payload/usercontroller/responses/DeleteFromPubliclyAvailableUsers.java
@@ -1,0 +1,7 @@
+package com.azkar.payload.usercontroller.responses;
+
+import com.azkar.payload.ResponseBase;
+
+public class DeleteFromPubliclyAvailableUsers extends ResponseBase {
+
+}

--- a/src/main/java/com/azkar/payload/usercontroller/responses/GetPubliclyAvailableUsersResponse.java
+++ b/src/main/java/com/azkar/payload/usercontroller/responses/GetPubliclyAvailableUsersResponse.java
@@ -1,0 +1,25 @@
+package com.azkar.payload.usercontroller.responses;
+
+import com.azkar.payload.ResponseBase;
+import com.azkar.payload.usercontroller.responses.GetPubliclyAvailableUsersResponse.PubliclyAvailableUser;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class GetPubliclyAvailableUsersResponse extends ResponseBase<List<PubliclyAvailableUser>> {
+
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Setter
+  public static class PubliclyAvailableUser {
+
+    private String userId;
+    private String firstName;
+    private String lastName;
+  }
+}

--- a/src/main/java/com/azkar/repos/PubliclyAvailableFemaleUsersRepo.java
+++ b/src/main/java/com/azkar/repos/PubliclyAvailableFemaleUsersRepo.java
@@ -1,0 +1,13 @@
+package com.azkar.repos;
+
+import com.azkar.entities.PubliclyAvailableFemaleUser;
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PubliclyAvailableFemaleUsersRepo extends
+    MongoRepository<PubliclyAvailableFemaleUser, String> {
+
+  Optional<PubliclyAvailableFemaleUser> findByUserId(String userId);
+}

--- a/src/main/java/com/azkar/repos/PubliclyAvailableMaleUsersRepo.java
+++ b/src/main/java/com/azkar/repos/PubliclyAvailableMaleUsersRepo.java
@@ -1,0 +1,14 @@
+package com.azkar.repos;
+
+import com.azkar.entities.PubliclyAvailableMaleUser;
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PubliclyAvailableMaleUsersRepo extends
+    MongoRepository<PubliclyAvailableMaleUser, String> {
+
+  Optional<PubliclyAvailableMaleUser> findByUserId(String userId);
+
+}

--- a/src/test/java/com/azkar/TestBase.java
+++ b/src/test/java/com/azkar/TestBase.java
@@ -75,9 +75,7 @@ public abstract class TestBase {
       return;
     }
     BEFORE_ALL_DONE = true;
-    mongoTemplate.getCollectionNames().stream().forEach(name -> {
-      mongoTemplate.dropCollection(name);
-    });
+
     mongobee.execute();
   }
 

--- a/src/test/java/com/azkar/controllers/usercontroller/PubliclyAvailableUsersTest.java
+++ b/src/test/java/com/azkar/controllers/usercontroller/PubliclyAvailableUsersTest.java
@@ -1,0 +1,334 @@
+package com.azkar.controllers.usercontroller;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.azkar.TestBase;
+import com.azkar.controllers.utils.AzkarApi;
+import com.azkar.controllers.utils.JsonHandler;
+import com.azkar.entities.PubliclyAvailableFemaleUser;
+import com.azkar.entities.PubliclyAvailableMaleUser;
+import com.azkar.entities.User;
+import com.azkar.payload.ResponseBase.Status;
+import com.azkar.payload.usercontroller.responses.AddToPubliclyAvailableUsersResponse;
+import com.azkar.payload.usercontroller.responses.DeleteFromPubliclyAvailableUsers;
+import com.azkar.payload.usercontroller.responses.GetPubliclyAvailableUsersResponse;
+import com.azkar.payload.usercontroller.responses.GetPubliclyAvailableUsersResponse.PubliclyAvailableUser;
+import com.azkar.repos.PubliclyAvailableFemaleUsersRepo;
+import com.azkar.repos.PubliclyAvailableMaleUsersRepo;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+public class PubliclyAvailableUsersTest extends TestBase {
+
+  @Autowired
+  AzkarApi azkarApi;
+  @Autowired
+  PubliclyAvailableMaleUsersRepo publiclyAvailableMaleUsersRepo;
+  @Autowired
+  PubliclyAvailableFemaleUsersRepo publiclyAvailableFemaleUsersRepo;
+
+  @Before
+  public void before() {
+    publiclyAvailableMaleUsersRepo.deleteAll();
+    publiclyAvailableFemaleUsersRepo.deleteAll();
+  }
+
+  @Test
+  public void addToPubliclyAvailableMaleUsers_normalScenario_shouldSucceed() throws Exception {
+    // Add first male user.
+    User maleUser1 = getNewRegisteredUser();
+    azkarApi.addToPubliclyAvailableMales(maleUser1)
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(new AddToPubliclyAvailableUsersResponse())));
+
+    PubliclyAvailableMaleUser publiclyAvailableMaleUserInDb =
+        Iterators.getOnlyElement(publiclyAvailableMaleUsersRepo.findAll().iterator());
+    assertThat(publiclyAvailableMaleUserInDb.getUserId(), equalTo(maleUser1.getId()));
+    assertThat(publiclyAvailableMaleUserInDb.getFirstName(), equalTo(maleUser1.getFirstName()));
+    assertThat(publiclyAvailableMaleUserInDb.getLastName(), equalTo(maleUser1.getLastName()));
+
+    // Add second male user.
+    User maleUser2 = getNewRegisteredUser();
+    azkarApi.addToPubliclyAvailableMales(maleUser2)
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(new AddToPubliclyAvailableUsersResponse())));
+
+    List<PubliclyAvailableMaleUser> publiclyAvailableMaleUsersInDb =
+        publiclyAvailableMaleUsersRepo.findAll();
+    assertThat(publiclyAvailableMaleUsersInDb.get(0).getUserId(), equalTo(maleUser1.getId()));
+    assertThat(publiclyAvailableMaleUsersInDb.get(1).getUserId(), equalTo(maleUser2.getId()));
+
+    // Add first female user.
+    User femaleUser1 = getNewRegisteredUser();
+    azkarApi.addToPubliclyAvailableFemales(femaleUser1)
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(new AddToPubliclyAvailableUsersResponse())));
+
+    PubliclyAvailableFemaleUser publiclyAvailableFemaleUserInDb =
+        Iterators.getOnlyElement(publiclyAvailableFemaleUsersRepo.findAll().iterator());
+    assertThat(publiclyAvailableFemaleUserInDb.getUserId(), equalTo(femaleUser1.getId()));
+    assertThat(publiclyAvailableFemaleUserInDb.getFirstName(), equalTo(femaleUser1.getFirstName()));
+    assertThat(publiclyAvailableFemaleUserInDb.getLastName(), equalTo(femaleUser1.getLastName()));
+    publiclyAvailableMaleUsersInDb =
+        publiclyAvailableMaleUsersRepo.findAll();
+    assertThat(publiclyAvailableMaleUsersInDb.get(0).getUserId(), equalTo(maleUser1.getId()));
+    assertThat(publiclyAvailableMaleUsersInDb.get(1).getUserId(), equalTo(maleUser2.getId()));
+
+    // Add second male user.
+    User femaleUser2 = getNewRegisteredUser();
+    azkarApi.addToPubliclyAvailableFemales(femaleUser2)
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(new AddToPubliclyAvailableUsersResponse())));
+
+    List<PubliclyAvailableFemaleUser> publiclyAvailableFemaleUsersInDb =
+        publiclyAvailableFemaleUsersRepo.findAll();
+    assertThat(publiclyAvailableFemaleUsersInDb.get(0).getUserId(), equalTo(femaleUser1.getId()));
+    assertThat(publiclyAvailableFemaleUsersInDb.get(1).getUserId(), equalTo(femaleUser2.getId()));
+    publiclyAvailableMaleUsersInDb =
+        publiclyAvailableMaleUsersRepo.findAll();
+    assertThat(publiclyAvailableMaleUsersInDb.get(0).getUserId(), equalTo(maleUser1.getId()));
+    assertThat(publiclyAvailableMaleUsersInDb.get(1).getUserId(), equalTo(maleUser2.getId()));
+  }
+
+  @Test
+  public void addToPubliclyAvailableMaleUsers_alreadyAdded_shouldFail() throws Exception {
+    // Add male user
+    User maleUser = getNewRegisteredUser();
+    azkarApi.addToPubliclyAvailableMales(maleUser)
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(new AddToPubliclyAvailableUsersResponse())));
+
+    AddToPubliclyAvailableUsersResponse expectedResponse =
+        new AddToPubliclyAvailableUsersResponse();
+    expectedResponse.setStatus(new Status(Status.USER_ALREADY_IS_PUBLICLY_AVAILABLE_USER_ERROR));
+    azkarApi.addToPubliclyAvailableMales(maleUser)
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse)));
+    azkarApi.addToPubliclyAvailableFemales(maleUser)
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse)));
+
+    // Add female user
+    User femaleUser = getNewRegisteredUser();
+    azkarApi.addToPubliclyAvailableFemales(femaleUser)
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(new AddToPubliclyAvailableUsersResponse())));
+
+    azkarApi.addToPubliclyAvailableMales(femaleUser)
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse)));
+    azkarApi.addToPubliclyAvailableFemales(femaleUser)
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse)));
+  }
+
+  @Test
+  public void deleteFromPubliclyAvailableUsers_normalScenario_shouldSucceed() throws Exception {
+    // Add first male user.
+    User maleUser1 = getNewRegisteredUser();
+    azkarApi.addToPubliclyAvailableMales(maleUser1);
+
+    // Add second male user.
+    User maleUser2 = getNewRegisteredUser();
+    azkarApi.addToPubliclyAvailableMales(maleUser2);
+
+    // Add female user.
+    User femaleUser = getNewRegisteredUser();
+    azkarApi.addToPubliclyAvailableFemales(femaleUser);
+
+    azkarApi.deleteFromPubliclyAvailableUsers(maleUser2)
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(new DeleteFromPubliclyAvailableUsers())));
+
+    PubliclyAvailableMaleUser publiclyAvailableMaleUserInDb =
+        Iterators.getOnlyElement(publiclyAvailableMaleUsersRepo.findAll().iterator());
+    assertThat(publiclyAvailableMaleUserInDb.getUserId(), equalTo(maleUser1.getId()));
+    PubliclyAvailableFemaleUser publiclyAvailableFemaleUserInDb =
+        Iterators.getOnlyElement(publiclyAvailableFemaleUsersRepo.findAll().iterator());
+    assertThat(publiclyAvailableFemaleUserInDb.getUserId(), equalTo(femaleUser.getId()));
+  }
+
+  @Test
+  public void deleteFromPubliclyAvailableUsers_notAddedBefore_shouldFail() throws Exception {
+    User maleUser1 = getNewRegisteredUser();
+    User femaleUser1 = getNewRegisteredUser();
+    User userToBeDeleted = getNewRegisteredUser();
+
+    azkarApi.addToPubliclyAvailableMales(maleUser1);
+    azkarApi.addToPubliclyAvailableFemales(femaleUser1);
+
+    DeleteFromPubliclyAvailableUsers expectedResponse = new DeleteFromPubliclyAvailableUsers();
+    expectedResponse.setStatus(new Status(Status.USER_NOT_ADDED_TO_PUBLICLY_AVAILABLE_USERS_ERROR));
+
+    azkarApi.deleteFromPubliclyAvailableUsers(userToBeDeleted)
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse)));
+  }
+
+  @Test
+  public void getPubliclyAvailableUsers_normalScenario_shouldSucceed() throws Exception {
+    // Add male user 1
+    User maleUser1 = getNewRegisteredUser();
+    azkarApi.addToPubliclyAvailableMales(maleUser1);
+
+    GetPubliclyAvailableUsersResponse expectedResponse = new GetPubliclyAvailableUsersResponse();
+    List<PubliclyAvailableUser> expectedPubliclyAvailableUsers = ImmutableList.of(
+        PubliclyAvailableUser.builder()
+            .userId(maleUser1.getId())
+            .firstName(maleUser1.getFirstName())
+            .lastName(maleUser1.getLastName())
+            .build());
+    expectedResponse.setData(expectedPubliclyAvailableUsers);
+    azkarApi.getPubliclyAvailableUsers(maleUser1)
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse)));
+
+    // Add male user 2
+    User maleUser2 = getNewRegisteredUser();
+    azkarApi.addToPubliclyAvailableMales(maleUser2);
+
+    expectedPubliclyAvailableUsers = ImmutableList.of(
+        PubliclyAvailableUser.builder()
+            .userId(maleUser1.getId())
+            .firstName(maleUser1.getFirstName())
+            .lastName(maleUser1.getLastName())
+            .build(),
+        PubliclyAvailableUser.builder()
+            .userId(maleUser2.getId())
+            .firstName(maleUser2.getFirstName())
+            .lastName(maleUser2.getLastName())
+            .build()
+    );
+    expectedResponse.setData(expectedPubliclyAvailableUsers);
+    azkarApi.getPubliclyAvailableUsers(maleUser1)
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse)));
+    azkarApi.getPubliclyAvailableUsers(maleUser2)
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse)));
+
+    // Add female user 1
+    User femaleUser1 = getNewRegisteredUser();
+    azkarApi.addToPubliclyAvailableFemales(femaleUser1);
+
+    expectedPubliclyAvailableUsers = ImmutableList.of(
+        PubliclyAvailableUser.builder()
+            .userId(femaleUser1.getId())
+            .firstName(femaleUser1.getFirstName())
+            .lastName(femaleUser1.getLastName())
+            .build());
+    expectedResponse.setData(expectedPubliclyAvailableUsers);
+    azkarApi.getPubliclyAvailableUsers(femaleUser1)
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse)));
+
+    // Add female user 2
+    User femaleUser2 = getNewRegisteredUser();
+    azkarApi.addToPubliclyAvailableFemales(femaleUser2);
+
+    expectedPubliclyAvailableUsers = ImmutableList.of(
+        PubliclyAvailableUser.builder()
+            .userId(femaleUser1.getId())
+            .firstName(femaleUser1.getFirstName())
+            .lastName(femaleUser1.getLastName())
+            .build(),
+        PubliclyAvailableUser.builder()
+            .userId(femaleUser2.getId())
+            .firstName(femaleUser2.getFirstName())
+            .lastName(femaleUser2.getLastName())
+            .build()
+    );
+    expectedResponse.setData(expectedPubliclyAvailableUsers);
+    azkarApi.getPubliclyAvailableUsers(femaleUser1)
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse)));
+    azkarApi.getPubliclyAvailableUsers(femaleUser2)
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse)));
+
+    // Delete male user 1
+    azkarApi.deleteFromPubliclyAvailableUsers(maleUser1);
+
+    expectedPubliclyAvailableUsers = ImmutableList.of(
+        PubliclyAvailableUser.builder()
+            .userId(maleUser2.getId())
+            .firstName(maleUser2.getFirstName())
+            .lastName(maleUser2.getLastName())
+            .build()
+    );
+    expectedResponse.setData(expectedPubliclyAvailableUsers);
+    azkarApi.getPubliclyAvailableUsers(maleUser2)
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse)));
+
+    expectedPubliclyAvailableUsers = ImmutableList.of(
+        PubliclyAvailableUser.builder()
+            .userId(femaleUser1.getId())
+            .firstName(femaleUser1.getFirstName())
+            .lastName(femaleUser1.getLastName())
+            .build(),
+        PubliclyAvailableUser.builder()
+            .userId(femaleUser2.getId())
+            .firstName(femaleUser2.getFirstName())
+            .lastName(femaleUser2.getLastName())
+            .build()
+    );
+    expectedResponse.setData(expectedPubliclyAvailableUsers);
+    azkarApi.getPubliclyAvailableUsers(femaleUser1)
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse)));
+    azkarApi.getPubliclyAvailableUsers(femaleUser2)
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse)));
+
+    expectedResponse.setData(null);
+    expectedResponse.setStatus(new Status(Status.USER_NOT_ADDED_TO_PUBLICLY_AVAILABLE_USERS_ERROR));
+
+    azkarApi.getPubliclyAvailableUsers(maleUser1)
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse)));
+  }
+
+  @Test
+  public void getPubliclyAvailableUsers_notAddedBefore_shouldFail() throws Exception {
+    User user = getNewRegisteredUser();
+
+    GetPubliclyAvailableUsersResponse expectedResponse = new GetPubliclyAvailableUsersResponse();
+    expectedResponse.setStatus(new Status(Status.USER_NOT_ADDED_TO_PUBLICLY_AVAILABLE_USERS_ERROR));
+
+    azkarApi.getPubliclyAvailableUsers(user)
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse)));
+  }
+}

--- a/src/test/java/com/azkar/controllers/utils/AzkarApi.java
+++ b/src/test/java/com/azkar/controllers/utils/AzkarApi.java
@@ -19,6 +19,9 @@ import com.azkar.payload.challengecontroller.responses.GetChallengeResponse;
 import com.azkar.payload.groupcontroller.requests.AddGroupRequest;
 import com.azkar.payload.groupcontroller.responses.AddGroupResponse;
 import com.azkar.payload.usercontroller.requests.SetNotificationTokenRequestBody;
+import com.azkar.payload.usercontroller.responses.GetPubliclyAvailableUsersResponse;
+import com.azkar.payload.usercontroller.responses.GetPubliclyAvailableUsersResponse.PubliclyAvailableUser;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.test.web.servlet.MvcResult;
@@ -40,6 +43,31 @@ public class AzkarApi {
 
   public ResultActions getUserById(User user, String id) throws Exception {
     return httpClient.performGetRequest(user, String.format("/users/%s", id));
+  }
+
+  public ResultActions getPubliclyAvailableUsers(User user) throws Exception {
+    return httpClient.performGetRequest(user, "/users/publicly_available_users");
+  }
+
+  public List<PubliclyAvailableUser> getPubliclyAvailableUsersAndReturn(User user)
+      throws Exception {
+    MvcResult result = getPubliclyAvailableUsers(user).andReturn();
+    GetPubliclyAvailableUsersResponse response =
+        JsonHandler.fromJson(result.getResponse().getContentAsString(),
+            GetPubliclyAvailableUsersResponse.class);
+    return response.getData();
+  }
+
+  public ResultActions addToPubliclyAvailableMales(User user) throws Exception {
+    return httpClient.performPutRequest(user, "/users/publicly_available_males");
+  }
+
+  public ResultActions addToPubliclyAvailableFemales(User user) throws Exception {
+    return httpClient.performPutRequest(user, "/users/publicly_available_females");
+  }
+
+  public ResultActions deleteFromPubliclyAvailableUsers(User user) throws Exception {
+    return httpClient.performDeleteRequest(user, "/users/publicly_available_users");
   }
 
   public ResultActions searchForUserByUsername(User user, String username) throws Exception {


### PR DESCRIPTION
It has been requested multiple times from multiple users to allow them to be able to find friends through the app so that they can challenge each other.

This PR adds the following endpoints:

- PUT users/publicly_available_males: This will add the user to the list of the publicly available males and will allow them to view the list and send friend requests to users from it.
- PUT users/publicly_available_females: This will add the user to the list of the publicly available females and will allow them to view the list and send friend requests to users from it.
- DELETE users/publicly_available_users: This will remove the user from the publicly available list they are added to.
- GET users/publicly_available_users: This will return the list of publicly available users that this user si added to.