### PR TITLE
Cleanup users with no friendships

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ server:
     key-store-password: ${KEY_STORE_PASSWORD}
     key-store-type: PKCS12
     key-store: classpath:tanafaso.p12
-    enabled: false
+    enabled: true
 
 spring:
   main:


### PR DESCRIPTION
In one bad release, we have used com/sun/tools/javac/util/List and that affected some new
 users using UserService in such a way that those users were actually created but no
 friendships or test challenges were added to them.
 The bad dependency was solved in https://github.com/tanafaso/tanafaso-backend/pull/351